### PR TITLE
Relax numpy requirement to >=1.26

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
   "datamart_profiler==0.11",
   "fastembed==0.5.1",
   "nltk==3.9.1",
-  "numpy>=2.2.2",
+  "numpy>=1.26",
   "openai==1.61.0",
   "pandas>=2.2.3",
   "rank-bm25==0.2.2",


### PR DESCRIPTION
The package's numpy usage (ranking/metrics.py, search/engine.py) is limited to long-stable APIs (np.sum, np.dot, np.argsort, np.average, linalg.norm), all fully compatible with numpy 1.26. The >=2.2.2 floor needlessly blocks environments stuck on numpy 1.x — e.g. Intel macOS, where torch wheels stop at 2.2.2 (built against numpy 1.x), so installing autoddg alongside torch forces a numpy 2.x + torch 1.x-ABI mismatch that breaks tensor<->numpy interop. Verified: full describe/search pipeline imports and runs on numpy 1.26.4.